### PR TITLE
Add simple stock up/down correlation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # algo-basic-trend
+
+This repository contains a simple example for analysing whether a stock's daily
+close ends up or down from the previous day using 2024 market data. The
+`daily_up_prob.py` script downloads prices with **yfinance** and calculates:
+
+- Correlation between the up/down indicator and its values over the previous
+  1--4 days.
+- The probability that a day closes higher, provided the previous `n` days were
+  all higher (`n` from 1 to 4).
+
+## Usage
+
+Run the script with Python. It uses yfinance to fetch data, so an internet
+connection and the `yfinance` package are required:
+
+```bash
+pip install yfinance
+python3 daily_up_prob.py
+```
+
+By default it analyses AAPL, MSFT and GOOG for the 2024 calendar year. You can
+edit the ticker list in the `main` block or call `analyze_tickers` with your
+own list of symbols.

--- a/daily_up_prob.py
+++ b/daily_up_prob.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import yfinance as yf
+
+
+def get_stock_data(ticker: str, start: str, end: str) -> pd.DataFrame:
+    """Download daily price data for a ticker."""
+    df = yf.download(ticker, start=start, end=end, progress=False)
+    return df
+
+
+def compute_up_indicator(df: pd.DataFrame) -> pd.Series:
+    """Return a Series of 1 if close is higher than previous day's close, else 0."""
+    up = df['Close'].diff().gt(0).astype(int)
+    return up
+
+
+def compute_statistics(up: pd.Series, max_days: int = 4):
+    """Return lag correlations and conditional probabilities for up indicator."""
+    lag_corr = {}
+    cond_prob = {}
+    for n in range(1, max_days + 1):
+        lag_corr[n] = up.corr(up.shift(n))
+        cond = up.shift(1).rolling(n).mean() == 1
+        cond_prob[n] = up[cond].mean()
+    return lag_corr, cond_prob
+
+
+def analyze_tickers(tickers, start="2024-01-01", end="2025-01-01"):
+    for ticker in tickers:
+        print(f"--- {ticker} ---")
+        df = get_stock_data(ticker, start=start, end=end)
+        up = compute_up_indicator(df)
+        lag_corr, cond_prob = compute_statistics(up)
+        print("Lag correlations (corr with previous n days):")
+        for n, c in lag_corr.items():
+            print(f"  Lag {n}: {c:.3f}")
+        print("Probability next day is up if previous n days were all up:")
+        for n, p in cond_prob.items():
+            print(f"  {n} days up -> {p:.3f}")
+        print()
+
+
+if __name__ == "__main__":
+    analyze_tickers(["AAPL", "MSFT", "GOOG"])


### PR DESCRIPTION
## Summary
- add `daily_up_prob.py` to download 2024 prices with yfinance and compute
  lag correlations and conditional probabilities for up days
- document usage in README

## Testing
- `python3 -m py_compile daily_up_prob.py`

------
https://chatgpt.com/codex/tasks/task_e_6843ded8884c832d8a427eb38f5a1e66